### PR TITLE
fix: avoid mutating input array

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ var Q = require('q');
 
 function splitDo(origAr, splitBy, cb){
   var deferred;
-  var origAr = origAr;
 
   // Check for existence of done callback to see if this should work non-blocking.
   var hasDoneCallback = cb.length > 1;
@@ -21,14 +20,18 @@ function splitDo(origAr, splitBy, cb){
   }
 
   // For better usability: If splitBy is one, don't pass array segments.
-  if (splitBy == 1){
-    splitArrays = origAr;
-  }else{
+  if (splitBy === 1){
+    // Shallow copy to prevent accidental mutation of the original array
+    splitArrays = origAr.slice();
+  } else {
     splitArrays = [];
 
+    // Work on a copy so the original array is not modified
+    var workingArray = origAr.slice();
+
     // Split the origArray into multiple arrays.
-    while (origAr.length > 0){
-      splitArrays.push(origAr.splice(0, splitBy));
+    while (workingArray.length > 0){
+      splitArrays.push(workingArray.splice(0, splitBy));
     }
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,5 @@
 var splitDo = require('../');
+var assert = require('assert');
 
 var testAr1 = [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15];
 var testAr2 = [1,2,3,4,5,6,7,8,9,10,11,12,13,14];
@@ -108,3 +109,13 @@ splitDo(testAr7, 1, function(item, done, segmentNumber, allSegments){
 }).then(function(){
   console.log('test7 done');
 });
+
+// Ensure the original array is not mutated.
+console.log('test8 start');
+var original = [1,2,3,4];
+var originalCopy = original.slice();
+splitDo(original, 2, function(){
+  // no-op
+});
+assert.deepStrictEqual(original, originalCopy);
+console.log('test8 done');


### PR DESCRIPTION
## Summary
- prevent `splitDo` from mutating the source array by working on a copy
- add regression test ensuring arrays remain intact after processing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894e279f7ac832981a0610fd12de9b1