### PR TITLE
Include passed values in error messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,11 +13,11 @@ function splitDo(origAr, splitBy, cb){
 
   // Sanity checks.
   if (typeof splitBy !== 'number'){
-    throw new Error('splitBy argument must be a number. Passed:', splitBy);
+    throw new Error('splitBy argument must be a number. Passed: ' + splitBy);
   }
 
   if (!(origAr instanceof Array)){
-    throw new Error('origAr argument must be an array. Passed:', origAr);
+    throw new Error('origAr argument must be an array. Passed: ' + origAr);
   }
 
   // For better usability: If splitBy is one, don't pass array segments.


### PR DESCRIPTION
## Summary
- Include `splitBy` and `origAr` values in thrown error messages for clearer debugging.

## Testing
- `npm test`
- `node -e "var splitDo=require('./'); try{splitDo([], 'notNumber', function(){})}catch(e){console.log(e.message)}; try{splitDo('notArray', 2, function(){})}catch(e){console.log(e.message)}"`


------
https://chatgpt.com/codex/tasks/task_e_6894e50cbe3883299b85c72f2b6e86ca