### PR TITLE
Use assertions in test suite

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -1,110 +1,159 @@
-var splitDo = require('../');
+const assert = require('assert');
+const splitDo = require('../');
 
-var testAr1 = [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15];
-var testAr2 = [1,2,3,4,5,6,7,8,9,10,11,12,13,14];
-var testAr3 = [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16];
-var testAr4 = [
-  [1,'a','b'],
-  [2,'a','b'],
-  [3,'a','b'],
-  [4,'a','b'],
-  [5,'a','b'],
-  [6,'a','b'],
-  [7,'a','b'],
-  [8,'a','b'],
-  [9,'a','b'],
-  [10,'a','b'],
-  [11,'a','b'],
-  [12,'a','b'],
-  [13,'a','b'],
-  [14,'a','b'],
-  [15,'a','b']
-];
+async function test1() {
+  const input = Array.from({ length: 15 }, (_, i) => i + 1);
+  const expected = [
+    [1, 2, 3],
+    [4, 5, 6],
+    [7, 8, 9],
+    [10, 11, 12],
+    [13, 14, 15],
+  ];
+  const chunks = [];
+  const result = splitDo(input.slice(), 3, segment => chunks.push(segment));
+  assert.strictEqual(result, undefined);
+  assert.strictEqual(chunks.length, expected.length);
+  assert.deepStrictEqual(chunks, expected);
+}
 
-var testAr5 = [
-  [1,'a','b'],
-  [2,'a','b'],
-  [3,'a','b'],
-  [4,'a','b'],
-  [5,'a','b'],
-  [6,'a','b'],
-  [7,'a','b'],
-  [8,'a','b'],
-  [9,'a','b'],
-  [10,'a','b'],
-  [11,'a','b'],
-  [12,'a','b'],
-  [13,'a','b'],
-  [14,'a','b'],
-  [15,'a','b']
-];
+async function test2() {
+  const input = Array.from({ length: 14 }, (_, i) => i + 1);
+  const expected = [
+    [1, 2, 3],
+    [4, 5, 6],
+    [7, 8, 9],
+    [10, 11, 12],
+    [13, 14],
+  ];
+  const chunks = [];
+  splitDo(input.slice(), 3, segment => chunks.push(segment));
+  assert.strictEqual(chunks.length, expected.length);
+  assert.deepStrictEqual(chunks, expected);
+}
 
-var testAr6 = [1,2,3,4,5,6];
-var testAr7 = [{"a":"1"}, {"b":"2"},{"c":"3"}];
-
-// Make sure each item gets called correctly. (regular, blocking)
-console.log('test1 start');
-splitDo(testAr1, 3, function(item){
-  console.log('test1: item', item);
-});
-console.log('test1 done');
-
-
-// Check off by one -1 (regular, blocking)
-console.log('test2 start');
-splitDo(testAr2, 3, function(item){
-  console.log('test2: item', item);
-});
-console.log('test2 done');
-
-// Check off by one +1 (non-blocking)
-console.log('test3 start');
-splitDo(testAr3, 3, function(item, done){
-  console.log('test3: item', item);
-  done();
-}).then(function(){
-  console.log('test3 done');
-});
-
-// Check multi dimensional array (non-blocking)
-console.log('test4 start');
-splitDo(testAr4, 3, function(item, done){
-  console.log('test4: item', item);
-  done();
-}).then(function(){
-  console.log('test4 done');
-});
-
-// Check multi dimensional array with timeout to prove (non-blocking)
-console.log('test5 start');
-splitDo(testAr5, 3, function(item, done, segmentNumber, allSegments){
-  setTimeout(function(){
-    console.log('test5: item', item);
+async function test3() {
+  const input = Array.from({ length: 16 }, (_, i) => i + 1);
+  const expected = [
+    [1, 2, 3],
+    [4, 5, 6],
+    [7, 8, 9],
+    [10, 11, 12],
+    [13, 14, 15],
+    [16],
+  ];
+  const chunks = [];
+  let resolved = false;
+  const promise = splitDo(input.slice(), 3, (segment, done) => {
+    chunks.push(segment);
     done();
-  }, 1000);
-}).then(function(){
-  console.log('test5 done');
-});
+  }).then(() => {
+    resolved = true;
+  });
+  assert.strictEqual(resolved, false);
+  await promise;
+  assert.strictEqual(resolved, true);
+  assert.strictEqual(chunks.length, expected.length);
+  assert.deepStrictEqual(chunks, expected);
+}
 
-// Check splitby one does not use array format.
-console.log('test6 start');
-splitDo(testAr6, 1, function(item, done, segmentNumber, allSegments){
-  console.log('arguments', arguments);
-  setTimeout(function(){
-    console.log('test6: item', item);
+async function test4() {
+  const input = Array.from({ length: 15 }, (_, i) => [i + 1, 'a', 'b']);
+  const expected = [
+    [ [1, 'a', 'b'], [2, 'a', 'b'], [3, 'a', 'b'] ],
+    [ [4, 'a', 'b'], [5, 'a', 'b'], [6, 'a', 'b'] ],
+    [ [7, 'a', 'b'], [8, 'a', 'b'], [9, 'a', 'b'] ],
+    [ [10, 'a', 'b'], [11, 'a', 'b'], [12, 'a', 'b'] ],
+    [ [13, 'a', 'b'], [14, 'a', 'b'], [15, 'a', 'b'] ],
+  ];
+  const chunks = [];
+  let resolved = false;
+  const promise = splitDo(input.slice(), 3, (segment, done) => {
+    chunks.push(segment);
     done();
-  }, 1000);
-}).then(function(){
-  console.log('test6 done');
-});
+  }).then(() => {
+    resolved = true;
+  });
+  assert.strictEqual(resolved, false);
+  await promise;
+  assert.strictEqual(resolved, true);
+  assert.strictEqual(chunks.length, expected.length);
+  assert.deepStrictEqual(chunks, expected);
+}
 
-// Check splitby one does not use array format.
-console.log('test7 start');
-splitDo(testAr7, 1, function(item, done, segmentNumber, allSegments){
-  setTimeout(function(){
-    console.log('test7: item', item);
-    done();
-  }, 1000);
-}).then(function(){
-  console.log('test7 done');
+async function test5() {
+  const input = Array.from({ length: 15 }, (_, i) => [i + 1, 'a', 'b']);
+  const expected = [
+    [ [1, 'a', 'b'], [2, 'a', 'b'], [3, 'a', 'b'] ],
+    [ [4, 'a', 'b'], [5, 'a', 'b'], [6, 'a', 'b'] ],
+    [ [7, 'a', 'b'], [8, 'a', 'b'], [9, 'a', 'b'] ],
+    [ [10, 'a', 'b'], [11, 'a', 'b'], [12, 'a', 'b'] ],
+    [ [13, 'a', 'b'], [14, 'a', 'b'], [15, 'a', 'b'] ],
+  ];
+  const chunks = [];
+  let resolved = false;
+  const promise = splitDo(input.slice(), 3, (segment, done) => {
+    setTimeout(() => {
+      chunks.push(segment);
+      done();
+    }, 0);
+  }).then(() => {
+    resolved = true;
+  });
+  assert.strictEqual(resolved, false);
+  await promise;
+  assert.strictEqual(resolved, true);
+  assert.strictEqual(chunks.length, expected.length);
+  assert.deepStrictEqual(chunks, expected);
+}
+
+async function test6() {
+  const input = [1, 2, 3, 4, 5, 6];
+  const received = [];
+  let resolved = false;
+  const promise = splitDo(input.slice(), 1, (item, done) => {
+    assert.strictEqual(Array.isArray(item), false);
+    received.push(item);
+    setTimeout(done, 0);
+  }).then(() => {
+    resolved = true;
+  });
+  assert.strictEqual(resolved, false);
+  await promise;
+  assert.strictEqual(resolved, true);
+  assert.strictEqual(received.length, input.length);
+  assert.deepStrictEqual(received, input);
+}
+
+async function test7() {
+  const input = [{ a: '1' }, { b: '2' }, { c: '3' }];
+  const received = [];
+  let resolved = false;
+  const promise = splitDo(input.slice(), 1, (item, done) => {
+    assert.strictEqual(Array.isArray(item), false);
+    received.push(item);
+    setTimeout(done, 0);
+  }).then(() => {
+    resolved = true;
+  });
+  assert.strictEqual(resolved, false);
+  await promise;
+  assert.strictEqual(resolved, true);
+  assert.strictEqual(received.length, input.length);
+  assert.deepStrictEqual(received, input);
+}
+
+async function runTests() {
+  await test1();
+  await test2();
+  await test3();
+  await test4();
+  await test5();
+  await test6();
+  await test7();
+}
+
+runTests().catch(err => {
+  console.error(err);
+  process.exit(1);
 });


### PR DESCRIPTION
## Summary
- Replace console-driven tests with Node.js `assert` checks
- Cover blocking and async scenarios, verifying chunk counts and promise resolution

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894e5114a9083298817f94f1be31ffc